### PR TITLE
Remove www. from start of url

### DIFF
--- a/makehook.js
+++ b/makehook.js
@@ -1,16 +1,16 @@
 var loc = window.location.href;
 var newloc = loc;
 if(newloc.includes("m.youtube.com")){
-        newloc=newloc.replace("m.youtube.com", "invidio.us");
+        newloc=newloc.replace("m.youtube.com", "invidious.snopyta.org");
 }
 else if (newloc.includes("youtube")){
-	newloc=newloc.replace("youtube.com", "invidio.us");
+	newloc=newloc.replace("youtube.com", "invidious.snopyta.org");
 }
 else if (newloc.includes("youtu.be")){
-	newloc=newloc.replace("youtu.be/", "invidio.us/watch?v=");
+	newloc=newloc.replace("youtu.be/", "invidious.snopyta.org/watch?v=");
 }
 else if (newloc.includes("youtube-nocookie")){
-	newloc=newloc.replace("youtube-nocookie.com/", "invidio.us/");
+	newloc=newloc.replace("youtube-nocookie.com/", "invidious.snopyta.org/");
 }
 if(newloc.includes("/results?q")){
         newloc=newloc.replace("/results?q", "/search?q");

--- a/makehook.js
+++ b/makehook.js
@@ -9,6 +9,9 @@ function onGot(item) {
   }
   var loc = window.location.href;
   var newloc = loc;
+  if (newloc.includes("https://www.")) {
+    newloc = newloc.replace("https://www.", "https://");
+  }
   if (newloc.includes("m.youtube.com")) {
     newloc = newloc.replace("m.youtube.com", instance);
   }


### PR DESCRIPTION
When using certain invidious instances (e.g. invidious.snopyta.org) having a "www." at the start of the url breaks it. This change removes it from the url (which shouldn't break other instances)